### PR TITLE
Updated to have Undo functionality for pixel colorization

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
             <canvas id="canvasPixelArtGenerator" width="600" height="600"></canvas>
         </div>
 
-        <p><u>Paint Controls:</u> <b>Left</b> click to paint pixel. <b>Right</b> click to set active paint color.</p>
+        <p><u>PaintControls:</u> <b>Left Click:</b> Paint pixel. <b>Right Click:</b> Set active paint color. <b>Ctrl + Z:</b> Undo Pixel Color Change.</p>
         <button disabled class="button" id="buttonSaveCanvasImage">Save Image</button>
 
     </div>


### PR DESCRIPTION
added an undo functionality where pixel color can be undone by pressing CTRL Z. there is an array that now holds a history of all clicked pixels that can be iterated through in reverse order to take back color changes.